### PR TITLE
The initial time is not read from the free-streaming module, when JET…

### DIFF
--- a/src/music.cpp
+++ b/src/music.cpp
@@ -95,7 +95,7 @@ void MUSIC::output_transport_coefficients() {
 
 
 void MUSIC::initialize_hydro_from_jetscape_preequilibrium_vectors(
-        const double dx, const double dz, const double z_max, const int nz,
+        const double tau0, const double dx, const double dz, const double z_max, const int nz,
         vector<double> e_in,
         vector<double> u_tau_in, vector<double> u_x_in,
         vector<double> u_y_in,   vector<double> u_eta_in,
@@ -117,6 +117,8 @@ void MUSIC::initialize_hydro_from_jetscape_preequilibrium_vectors(
     }
     DATA.delta_x = dx;
     DATA.delta_y = dx;
+    
+    DATA.tau0 = tau0;
 
     Init initialization(eos, DATA, hydro_source_terms);
     initialization.get_jetscape_preequilibrium_vectors(

--- a/src/music.h
+++ b/src/music.h
@@ -67,7 +67,7 @@ class MUSIC {
     void clean_all_the_surface_files();
 
     void initialize_hydro_from_jetscape_preequilibrium_vectors(
-        const double dx, const double dz, const double z_max, const int nz,
+        const double tau0, const double dx, const double dz, const double z_max, const int nz,
         std::vector<double> e_in,
         std::vector<double> u_tau_in, std::vector<double> u_x_in,
         std::vector<double> u_y_in,   std::vector<double> u_eta_in,


### PR DESCRIPTION
…SCAPE initial conditions are used