### PR TITLE
Output OAM area density Evolution

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -230,6 +230,7 @@ typedef struct init_data {
     int output_evolution_every_N_x;
     int output_evolution_every_N_y;
     int output_evolution_every_N_eta;
+    int output_OAM_density_Evolution;              //! output OAM area density evolution =>  0 to turn off,   1 for initial time step only , 2 for all time steps
     bool output_hydro_params_header;
     double output_evolution_T_cut;
     double output_evolution_e_cut;

--- a/src/evolve.cpp
+++ b/src/evolve.cpp
@@ -87,6 +87,7 @@ int Evolve::EvolveIt(
 
     int it = 0;
     double eps_max_cur = -1.;
+    int it_source_max = static_cast<int>((source_tau_max - tau0)/DATA.delta_tau + 0.5) + 1 ;
     const double max_allowed_e_increase_factor = 5.;
     double tau = tau0;
     const int NtauBlock = 200;
@@ -213,6 +214,13 @@ int Evolve::EvolveIt(
                         DATA.eta_size / 2.);
                 }
             }
+
+            if (DATA.output_OAM_density_Evolution == 2 ||
+                     (DATA.output_OAM_density_Evolution == 1 &&
+                     it == it_source_max)) {
+                grid_info.compute_Lmunu(*fpCurr, *fpPrev, tau);
+            }
+
 
             double emax_loc = 0.;
             double Tmax_curr = 0.;

--- a/src/grid_info.cpp
+++ b/src/grid_info.cpp
@@ -942,6 +942,156 @@ void Cell_info::get_maximum_energy_density(
     Tmax = T_max;
 }
 
+
+//! This function computes OAM area density at a give proper time
+void Cell_info::compute_Lmunu(
+    Fields &arena, Fields &arena_prev, const double tau) {
+
+    const double deta = DATA.delta_eta;
+    const double dx = DATA.delta_x;
+    const double dy = DATA.delta_y;
+    const int neta = arena.nEta();
+    const int nx = arena.nX();
+    const int ny = arena.nY();
+
+    ostringstream tau_suffix;
+    tau_suffix << std::fixed << std::setfill('0') << std::setw(7) << std::setprecision(3) << tau;
+    ostringstream filename;
+    filename << "Lmunu_angular_momentum_tau_" << tau_suffix.str() << ".dat";
+
+    ofstream output_file;
+           output_file.open(filename.str().c_str(), std::ofstream::out);
+           output_file << "# Tau = " << tau << "\n";
+           output_file << "# deta = " << deta << "\n";
+           output_file << "# dx = " << dx << "\n";
+           output_file << "# dy = " << dy << "\n";
+           output_file << "# neta = " << neta << "\n";
+           output_file << "# nx = " << nx << "\n";
+           output_file << "# ny = " << ny << "\n";
+
+           output_file << "Lx_xy[hbar fm^-2]   Ly_xy[hbar fm^-2]   Lz_xy[hbar fm^-2]   "
+                    << "L^{tx}_xy[hbar fm^-2]   L^{ty}_xy[hbar fm^-2]   L^{tz}_xy[hbar fm^-2]"
+                    << std::endl;
+
+
+
+
+    std::vector<std::vector<std::vector<double>>> Lx(neta, std::vector<std::vector<double>>(nx, std::vector<double>(ny, 0.0)));
+    std::vector<std::vector<std::vector<double>>> Ly = Lx;
+    std::vector<std::vector<std::vector<double>>> Lz = Lx;
+    std::vector<std::vector<std::vector<double>>> Ltx = Lx;
+    std::vector<std::vector<std::vector<double>>> Lty = Lx;
+    std::vector<std::vector<std::vector<double>>> Ltz = Lx;
+
+    std::vector<std::vector<double>> Lx_xy(nx, std::vector<double>(ny, 0.0));
+    std::vector<std::vector<double>> Ly_xy(nx, std::vector<double>(ny, 0.0));
+    std::vector<std::vector<double>> Lz_xy(nx, std::vector<double>(ny, 0.0));
+    std::vector<std::vector<double>> Ltx_xy(nx, std::vector<double>(ny, 0.0));
+    std::vector<std::vector<double>> Lty_xy(nx, std::vector<double>(ny, 0.0));
+    std::vector<std::vector<double>> Ltz_xy(nx, std::vector<double>(ny, 0.0));
+       
+  
+
+    for (int ieta = 0; ieta < neta; ieta++){
+        for (int ix = 0; ix < nx; ix++){
+            for (int iy = 0; iy < ny; iy++) {
+                const int Idx = arena.getFieldIdx(ix, iy, ieta);
+
+                double eta_s = deta * ieta - (DATA.eta_size) / 2.0;
+                const double cosh_eta = cosh(eta_s);
+                const double sinh_eta = sinh(eta_s);
+                const double t_local = tau * cosh_eta;
+                const double x_local = - DATA.x_size / 2.0 + ix * dx;
+                const double y_local = - DATA.y_size / 2.0 + iy * dy;
+                const double z_local = tau * sinh_eta;
+
+                const double e_local = arena.e_[Idx];
+                const double pressure =
+                    eos.get_pressure(e_local, arena.rhob_[Idx]);
+                const double u0 = arena.u_[0][Idx];
+                const double u1 = arena.u_[1][Idx];
+                const double u2 = arena.u_[2][Idx];
+                const double u3 = arena.u_[3][Idx];
+                const double uPrev0 = arena_prev.u_[0][Idx];
+                const double uPrev1 = arena_prev.u_[1][Idx];
+                const double uPrev2 = arena_prev.u_[2][Idx];
+                const double uPrev3 = arena_prev.u_[3][Idx];
+
+                const double T00_local =
+                    (e_local + pressure) * u0 * u0 - pressure;
+                const double Pi00_rk_0 =
+                    arena_prev.piBulk_[Idx] * (-1. + uPrev0 * uPrev0);
+
+                const double T_tau_tau =
+                    (T00_local + arena_prev.Wmunu_[0][Idx] + Pi00_rk_0);
+                const double T_tau_x =
+                    ((e_local + pressure) * u0 * u1 + arena_prev.Wmunu_[1][Idx]
+                     + arena_prev.piBulk_[Idx] * uPrev0 * uPrev1);
+                const double T_tau_y =
+                    ((e_local + pressure) * u0 * u2 + arena_prev.Wmunu_[2][Idx]
+                     + arena_prev.piBulk_[Idx] * uPrev0 * uPrev2);
+                const double T_tau_eta =
+                    ((e_local + pressure) * u0 * u3 + arena_prev.Wmunu_[3][Idx]
+                     + arena_prev.piBulk_[Idx] * uPrev0 * uPrev3);
+                const double T_tau_t =
+                    T_tau_tau * cosh_eta + T_tau_eta * sinh_eta;
+                const double T_tau_z =
+                    T_tau_tau * sinh_eta + T_tau_eta * cosh_eta;
+
+                
+                   Lx[ieta][ix][iy]  = y_local * T_tau_z - z_local * T_tau_y;
+                   Ly[ieta][ix][iy]  = z_local * T_tau_x - x_local * T_tau_z;
+                   Lz[ieta][ix][iy]  = x_local * T_tau_y - y_local * T_tau_x;
+
+                   Ltx[ieta][ix][iy] = t_local * T_tau_x - x_local * T_tau_t;
+                   Lty[ieta][ix][iy] = t_local * T_tau_y - y_local * T_tau_t;
+                   Ltz[ieta][ix][iy] = t_local * T_tau_z - z_local * T_tau_t;
+
+
+
+               }		  		   
+		 
+	}
+    }        
+
+// Integration over eta 
+// Lmunu area densities are written 
+
+
+  for (int ix = 0; ix < nx; ++ix) {
+     for (int iy = 0; iy < ny; ++iy) {
+         for (int ieta = 0; ieta < neta; ++ieta) {
+            
+	
+            const double dz = tau * deta;
+            Lx_xy[ix][iy]  += Lx[ieta][ix][iy]*dz;
+            Ly_xy[ix][iy]  += Ly[ieta][ix][iy]*dz;
+            Lz_xy[ix][iy]  += Lz[ieta][ix][iy]*dz;
+            Ltx_xy[ix][iy] += Ltx[ieta][ix][iy]*dz;
+            Lty_xy[ix][iy] += Lty[ieta][ix][iy]*dz;
+            Ltz_xy[ix][iy] += Ltz[ieta][ix][iy]*dz;
+        }
+
+        output_file << std::scientific << std::setprecision(6)
+                    << Lx_xy[ix][iy]  << " "
+                    << Ly_xy[ix][iy]  << " "
+                    << Lz_xy[ix][iy]  << " "
+                    << Ltx_xy[ix][iy] << " "
+                    << Lty_xy[ix][iy] << " "
+                    << Ltz_xy[ix][iy] << std::endl;
+       }
+  }
+  output_file.close();
+
+}
+
+
+
+
+
+
+
+
 //! This function computes global angular momentum at a give proper time
 void Cell_info::compute_angular_momentum(
     Fields &arena, Fields &arena_prev, const double tau, const double eta_min,

--- a/src/grid_info.h
+++ b/src/grid_info.h
@@ -112,6 +112,9 @@ class Cell_info {
     void output_energy_density_and_rhob_disitrubtion(
         Fields &arena, std::string filename);
 
+    //! This function writes OAM area densities Lmunu at a given proper time
+    void compute_Lmunu(Fields &arena, Fields &arena_prev, const double tau);
+
     //! This function computes global angular momentum at a give proper time
     void compute_angular_momentum(
         Fields &arena, Fields &arena_prev, const double tau,

--- a/src/read_in_parameters.cpp
+++ b/src/read_in_parameters.cpp
@@ -417,6 +417,8 @@ InitData read_in_parameters(std::string input_file) {
         (getParameter(input_file, "output_outofequilibriumsize", 0));
     parameter_list.output_vorticity =
         (getParameter(input_file, "output_vorticity", 0));
+    parameter_list.output_OAM_density_Evolution=
+        (getParameter(input_file, "output_OAM_density_Evolution", 0));
     parameter_list.output_hydro_debug_info =
         (getParameter(input_file, "output_hydro_debug_info", 0));
 
@@ -926,6 +928,12 @@ void check_parameters(InitData &parameter_list, std::string input_file) {
         exit(1);
     }
 
+    if (parameter_list.output_OAM_density_Evolution < 0
+              || parameter_list.output_OAM_density_Evolution > 2) {
+          music_message << "output_OAM_density_Evolution must be 0, 1, or 2: ";
+          music_message.flush("error");
+          exit(1);
+    }
     if (parameter_list.dNdy_eta_min > parameter_list.dNdy_eta_max) {
         music_message << "dNdy_eta_min = " << parameter_list.dNdy_eta_min
                       << " < "


### PR DESCRIPTION
I'm making this pull request for the OAM_density_Evolution changes only.

Highlights

Included a new function to write out the OAM area density at a given (\tau), defined in grid_info.cpp and called in evolve.cpp.

A new switch named output_OAM_density_Evolution has been introduced:

output_OAM_density_Evolution  0   # output OAM area density in hbar fm^-2
                                  # 0: off
                                  # 1: OAM density at initial tau
                                  # 2: OAM density for all time steps
Small inclusions were made in data.h, with corresponding checker statement in read_in_parameters.cpp.
